### PR TITLE
add google for build gradle repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,12 @@
 buildscript {
   repositories {
     jcenter()
+    google()
+    maven { url 'https://maven.google.com/' }
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.+'
+    classpath 'com.android.tools.build:gradle:3.2.1'
   }
 }
 


### PR DESCRIPTION
add google for build gradle repository.Because google delete com.android.tools.build:gradle in jcenter.
https://issuetracker.google.com/issues/120759347
please release a new version for this fix.