### PR TITLE
fix NPE

### DIFF
--- a/android/src/main/java/me/listenzz/modal/TranslucentModalHostView.java
+++ b/android/src/main/java/me/listenzz/modal/TranslucentModalHostView.java
@@ -37,6 +37,10 @@ public class TranslucentModalHostView extends ReactModalHostView {
     @TargetApi(23)
     private boolean isDark() {
         Activity activity = ((ReactContext) getContext()).getCurrentActivity();
+        // fix activity NPE
+        if (activity == null) {
+            return true;
+        }
         return (activity.getWindow().getDecorView().getSystemUiVisibility() & View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR) != 0;
     }
 


### PR DESCRIPTION
java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.Window android.app.Activity.getWindow()' on a null object reference
	at me.listenzz.modal.TranslucentModalHostView.isDark(TranslucentModalHostView.java:40)
	at me.listenzz.modal.TranslucentModalHostView.showOrUpdate(TranslucentModalHostView.java:32)
	at com.facebook.react.views.modal.ReactModalHostManager.onAfterUpdateTransaction(ReactModalHostManager.java:103)
	at com.facebook.react.views.modal.ReactModalHostManager.onAfterUpdateTransaction(ReactModalHostManager.java:24)
	at com.facebook.react.uimanager.ViewManager.updateProperties(ViewManager.java:33)
	at com.facebook.react.uimanager.NativeViewHierarchyManager.createView(NativeViewHierarchyManager.java:269)
	at com.facebook.react.uimanager.UIViewOperationQueue$CreateViewOperation.execute(UIViewOperationQueue.java:200)
	at com.facebook.react.uimanager.UIViewOperationQueue$1.run(UIViewOperationQueue.java:888)
	at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches(UIViewOperationQueue.java:1001)
	at com.facebook.react.uimanager.UIViewOperationQueue.access$2400(UIViewOperationQueue.java:46)
	at com.facebook.react.uimanager.UIViewOperationQueue$2.runGuarded(UIViewOperationQueue.java:959)
	at com.facebook.react.bridge.GuardedRunnable.run(GuardedRunnable.java:24)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:148)
	at android.app.ActivityThread.main(ActivityThread.java:5468)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:676)