### PR TITLE
Remove postinstall script from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "./node_modules/.bin/eslint --fix --ext .js ./ && echo \"lint finished\" ",
     "modal": "node scripts/translucent-modal.js",
-    "postinstall": "npm run modal"
   },
   "peerDependencies": {
     "react": ">=16.0.0",


### PR DESCRIPTION
I was trying to use this package as a standalone module (with the copy of JS part from `react-native` core). But the script always modifies the original package after install, which will cause some unexpected behaviours.

Since in the README, it already tells users to add the postinstall script manually, I suggest removing this from the package side.